### PR TITLE
GHC7.0.1向けの修正

### DIFF
--- a/executors/_hs
+++ b/executors/_hs
@@ -1,2 +1,2 @@
 #!/bin/sh
-ghc -O $1
+ghc -O -o a.out $1


### PR DESCRIPTION
caddyがGHC7.0.1で動作しなくなったので、修正をpullしていただけませんでしょうか？
GHC7.0.1では--makeモードが標準になったため、単一の.hsを引数にコンパイルした場合、
作成される実行ファイルがa.outではなくなりました。
そこで、明示的に出力ファイル名を指定するようにしました。
